### PR TITLE
T6017: http-api: update FastAPI for security advisory

### DIFF
--- a/requirements.in
+++ b/requirements.in
@@ -1,4 +1,4 @@
-fastapi==0.92.0
+fastapi
 python-multipart
 uvicorn[standard]
 wsproto

--- a/requirements.txt
+++ b/requirements.txt
@@ -4,15 +4,17 @@
 #
 #    pip-compile requirements.in
 #
-anyio==3.6.2
+annotated-types==0.6.0
+    # via pydantic
+anyio==4.2.0
     # via
     #   starlette
     #   watchfiles
-ariadne==0.19.1
+ariadne==0.22
     # via -r requirements.in
-click==8.1.3
+click==8.1.7
     # via uvicorn
-fastapi==0.92.0
+fastapi==0.109.2
     # via -r requirements.in
 graphql-core==3.2.3
     # via
@@ -22,43 +24,47 @@ h11==0.14.0
     # via
     #   uvicorn
     #   wsproto
-httptools==0.5.0
+httptools==0.6.1
     # via uvicorn
-idna==3.4
+idna==3.6
     # via anyio
-makefun==1.15.1
+makefun==1.15.2
     # via -r requirements.in
-pydantic==1.10.7
+pydantic==2.6.1
     # via fastapi
-pyjwt==2.6.0
+pydantic-core==2.16.2
+    # via pydantic
+pyjwt==2.8.0
     # via -r requirements.in
-python-dotenv==1.0.0
+python-dotenv==1.0.1
     # via uvicorn
-python-multipart==0.0.6
+python-multipart==0.0.7
     # via -r requirements.in
 python-pam==2.0.2
     # via -r requirements.in
-pyyaml==6.0
+pyyaml==6.0.1
     # via uvicorn
-sgqlc==16.1
+sgqlc==16.3
     # via -r requirements.in
 sniffio==1.3.0
     # via anyio
-starlette==0.25.0
+starlette==0.36.3
     # via
     #   ariadne
     #   fastapi
-typing-extensions==4.5.0
+typing-extensions==4.9.0
     # via
     #   ariadne
+    #   fastapi
     #   pydantic
-uvicorn[standard]==0.21.1
+    #   pydantic-core
+uvicorn[standard]==0.27.0.post1
     # via -r requirements.in
-uvloop==0.17.0
+uvloop==0.19.0
     # via uvicorn
-watchfiles==0.19.0
+watchfiles==0.21.0
     # via uvicorn
-websockets==11.0.2
+websockets==12.0
     # via uvicorn
 wsproto==1.2.0
     # via -r requirements.in


### PR DESCRIPTION
NOTE: this can be mergified for Sagitta, but Equuleus will have a separate PR as depends on package versions.

Update requirements.txt to include updates for security advisory:
https://github.com/advisories/GHSA-qf9m-vfgh-m389

This includes the automatic update generated in:
https://github.com/vyos/vyos-http-api-tools/pull/6
which will be closed.

Note that the update requires an adjustment to the smoketest:
https://github.com/vyos/vyos-1x/pull/2937