### PR TITLE
http-api: T6243: refresh requirements to include update for idna security advisory

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -6,15 +6,15 @@
 #
 annotated-types==0.6.0
     # via pydantic
-anyio==4.2.0
+anyio==4.3.0
     # via
     #   starlette
     #   watchfiles
-ariadne==0.22
+ariadne==0.23.0
     # via -r requirements.in
 click==8.1.7
     # via uvicorn
-fastapi==0.109.2
+fastapi==0.110.1
     # via -r requirements.in
 graphql-core==3.2.3
     # via
@@ -26,19 +26,19 @@ h11==0.14.0
     #   wsproto
 httptools==0.6.1
     # via uvicorn
-idna==3.6
+idna==3.7
     # via anyio
 makefun==1.15.2
     # via -r requirements.in
-pydantic==2.6.1
+pydantic==2.7.0
     # via fastapi
-pydantic-core==2.16.2
+pydantic-core==2.18.1
     # via pydantic
 pyjwt==2.8.0
     # via -r requirements.in
 python-dotenv==1.0.1
     # via uvicorn
-python-multipart==0.0.7
+python-multipart==0.0.9
     # via -r requirements.in
 python-pam==2.0.2
     # via -r requirements.in
@@ -46,19 +46,19 @@ pyyaml==6.0.1
     # via uvicorn
 sgqlc==16.3
     # via -r requirements.in
-sniffio==1.3.0
+sniffio==1.3.1
     # via anyio
-starlette==0.36.3
+starlette==0.37.2
     # via
     #   ariadne
     #   fastapi
-typing-extensions==4.9.0
+typing-extensions==4.11.0
     # via
     #   ariadne
     #   fastapi
     #   pydantic
     #   pydantic-core
-uvicorn[standard]==0.27.0.post1
+uvicorn[standard]==0.29.0
     # via -r requirements.in
 uvloop==0.19.0
     # via uvicorn


### PR DESCRIPTION
Regenerate requirements.txt for update of idna >= 3.7. Moderate severity denial of service advisory for package idna, as well as a good time for a general refresh of supporting packages before 1.4 release.

NOTE that this can be cherry-picked/mergified to Sagitta, but will need a manual backport for Equuleus.