### PR TITLE
general: T8595: add CLAUDE.md

### DIFF
--- a/.cursorrules
+++ b/.cursorrules
@@ -1,0 +1,1 @@
+CLAUDE.md

--- a/.cursorrules
+++ b/.cursorrules
@@ -1,1 +1,0 @@
-CLAUDE.md

--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -1,0 +1,1 @@
+../CLAUDE.md

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,1 @@
+CLAUDE.md

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,4 +1,4 @@
-# CLAUDE.md
+# vyos-http-api-tools — AI coding context
 
 ## Project purpose
 Debian packaging wrapper that bundles the Python runtime dependencies of the VyOS HTTP API (FastAPI, uvicorn, ariadne, etc.) as a single `.deb` installed on VyOS images. **Contains no application logic** — the actual HTTP API implementation lives in `vyos-1x/src/services/`. Maintained as a separate package so that not-yet-Debian-packaged Python libraries can ship and update independently of VyOS releases.
@@ -12,7 +12,7 @@ Debian packaging wrapper that bundles the Python runtime dependencies of the VyO
 ```
 dpkg-buildpackage -uc -us -tc -b
 # Update pinned versions from requirements.in:
-pip-compile requirements.in > requirements.txt
+pip-compile requirements.in  # writes requirements.txt by default
 ```
 No application-level test runner — the package is exercised at runtime by `vyos-1x`'s API services.
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -42,7 +42,3 @@ Mirror twin: `VyOS-Networks/vyos-http-api-tools`. Mirror status: gen-1 pipeline 
 - Any new library required by the HTTP API: append to `requirements.in`, regenerate `requirements.txt`, validate that the version installs cleanly inside `dh-virtualenv` (Python 3 + Debian bookworm).
 - After merge, `trigger-rebuild-repo-package.yml` fires REST `workflow_dispatch` into `$REMOTE_OWNER/vyos-build-packages` (REMOTE_OWNER = VyOS-Networks) to rebuild the `.deb` as `vyosbot`.
 - Watch FastAPI/uvicorn version pins for compat with the VyOS Python release (currently 3.11/3.12 on bookworm).
-
----
-
-This file is mirrored on Confluence: [`vyos/vyos-http-api-tools`](https://internal.confluence.vyos.com/wiki/spaces/VYOS/pages/818282936). The Confluence page also carries the per-repo audit data (settings, workflows, secret counts, hygiene) that complements this CLAUDE.md. Edit either side; resync via the documentation pipeline.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,0 +1,48 @@
+# CLAUDE.md
+
+## Project purpose
+Debian packaging wrapper that bundles the Python runtime dependencies of the VyOS HTTP API (FastAPI, uvicorn, ariadne, etc.) as a single `.deb` installed on VyOS images. **Contains no application logic** — the actual HTTP API implementation lives in `vyos-1x/src/services/`. Maintained as a separate package so that not-yet-Debian-packaged Python libraries can ship and update independently of VyOS releases.
+
+## Tech stack
+- Python — runtime dependency staging. `setup.py` + `requirements.in`/`requirements.txt`.
+- Debian packaging with `dh-virtualenv` (≥1.0). `debian/control` build-depends: `debhelper (>= 10)`, `python3`, `python3-setuptools`, `dh-virtualenv (>= 1.0)`, `python3-pip`, `python3-venv`.
+- Top-level `vyos-http-api-tools` directory is the install root copied into the venv.
+
+## Build / test / run
+```
+dpkg-buildpackage -uc -us -tc -b
+# Update pinned versions from requirements.in:
+pip-compile requirements.in > requirements.txt
+```
+No application-level test runner — the package is exercised at runtime by `vyos-1x`'s API services.
+
+## Repository layout
+- `vyos-http-api-tools/` — payload directory copied into the dh-virtualenv venv.
+- `requirements.in` — un-pinned top-level deps.
+- `requirements.txt` — pinned full graph (regenerate via `pip-compile`).
+- `setup.py` — packaging shim.
+- `debian/` — packaging files (`control`, `rules`, etc.).
+- `README.md` — explains the wrapper-only nature and lists upstream packages.
+
+## Cross-repo context
+- The actual HTTP API server code lives in `vyos/vyos-1x` (`python/vyos/`, `src/services/`, supporting Jinja2 templates and op-mode definitions). This repo only stages the runtime libs.
+- Built into ISOs by `vyos/vyos-build`; listed in `VyOS-Networks/vyos-build-packages/repos.toml` as one of the 14 canonical source repos.
+- Bundled libraries (per `README.md`): FastAPI, uvicorn, ariadne, makefun, sgqlc, pyjwt, python-pam, python-multipart, wsproto.
+
+## Conventions
+- Commit/PR title: `component: T12345: description` (Phorge task ID at https://vyos.dev). Enforced by `check-pr-message.yml` reusable.
+- Workflows: `pr-mirror-repo-sync.yml`, `trigger-rebuild-repo-package.yml`, `codeql.yml`, `cla-check.yml` (all `vyos/.github@current` reusables).
+- Bumping `requirements.in` → regenerate `requirements.txt` via `pip-compile` (`pip-tools`) in the same PR. Pin full graph for reproducible builds.
+
+## Mirror relationship
+Mirror twin: `VyOS-Networks/vyos-http-api-tools`. Mirror status: gen-1 pipeline workflow present (`pr-mirror-repo-sync.yml`); treat the `vyos/*` side as canonical.
+
+## Notes for future contributors
+- Do **not** add application logic here. Anything API-related goes in `vyos-1x`.
+- Any new library required by the HTTP API: append to `requirements.in`, regenerate `requirements.txt`, validate that the version installs cleanly inside `dh-virtualenv` (Python 3 + Debian bookworm).
+- After merge, `trigger-rebuild-repo-package.yml` fires REST `workflow_dispatch` into `$REMOTE_OWNER/vyos-build-packages` (REMOTE_OWNER = VyOS-Networks) to rebuild the `.deb` as `vyosbot`.
+- Watch FastAPI/uvicorn version pins for compat with the VyOS Python release (currently 3.11/3.12 on bookworm).
+
+---
+
+This file is mirrored on Confluence: [`vyos/vyos-http-api-tools`](https://internal.confluence.vyos.com/wiki/spaces/VYOS/pages/818282936). The Confluence page also carries the per-repo audit data (settings, workflows, secret counts, hygiene) that complements this CLAUDE.md. Edit either side; resync via the documentation pipeline.


### PR DESCRIPTION
## Summary

Adds a single source of truth for repo-level agent instructions, plus three symlinks so different agentic tools all read the same content from one canonical file.

**Files added:**

| Path | Type | Consumed by |
|---|---|---|
| `CLAUDE.md` | real file | Claude Code, Anthropic agents |
| `AGENTS.md` | symlink → `CLAUDE.md` | tools that follow the AGENTS.md convention (e.g. OpenAI Codex) |
| `.cursorrules` | symlink → `CLAUDE.md` | Cursor |
| `.github/copilot-instructions.md` | symlink → `../CLAUDE.md` | GitHub Copilot ([docs](https://docs.github.com/en/copilot/how-tos/configure-custom-instructions-in-your-ide/add-repository-instructions-in-your-ide)) |

**Rationale**

- One source of truth — guidance lives in `CLAUDE.md`, the symlinks are zero-content. No drift between four files.
- Each agentic tool reads its canonical filename and gets the same content.
- Mac/Linux dev environments handle symlinks natively. Windows checkouts may render them as text files containing the target path; the canonical `CLAUDE.md` is unaffected and still rendered/served correctly by GitHub.

**Out of scope**

Path-specific Copilot instructions (`.github/instructions/*.instructions.md`) need YAML frontmatter (`applyTo:`) and target specific globs, so they cannot be symlinks. Not added here; they can be authored as separate small files per-repo if/when narrow path-scoped guidance is needed.

Tracked under [T8595](https://vyos.dev/T8595).

## Test plan

- [ ] `CLAUDE.md` renders on GitHub.
- [ ] `AGENTS.md`, `.cursorrules`, `.github/copilot-instructions.md` resolve to CLAUDE.md content (`readlink` returns the right target).
- [ ] CI passes.

🤖 Generated by [robots](https://vyos.io)
