### PR TITLE
T8943: migrate pr-mirror wrapper to canonical stub

### DIFF
--- a/.github/workflows/pr-mirror-repo-sync.yml
+++ b/.github/workflows/pr-mirror-repo-sync.yml
@@ -6,7 +6,7 @@ name: PR Mirror and Repo Sync
 on:
   pull_request_target:
     types: [closed]
-    branches: [rolling]
+    branches: [rolling, production]
   workflow_dispatch:
     inputs:
       sync_branch:
@@ -14,16 +14,13 @@ on:
         type: string
 
 permissions:
-  contents: write
-  pull-requests: write
-  issues: write
+  contents: read
 
 jobs:
   call:
     if: |
       github.repository_owner == 'vyos'
       && (github.event.pull_request.merged == true || github.event_name == 'workflow_dispatch')
-      && vars.MIRROR_ENABLED != 'false'
     uses: vyos/.github/.github/workflows/pr-mirror-repo-sync.yml@production
     with:
       sync_branch: ${{ inputs.sync_branch || github.event.pull_request.base.ref }}


### PR DESCRIPTION
Mirror Pipeline Rollout 2 Task 6 — migrate this repo's `.github/workflows/pr-mirror-repo-sync.yml` to the canonical uniform stub: trigger `branches: [rolling, production]`, `permissions: contents: read`, drop the now-redundant wrapper-level `MIRROR_ENABLED` guard (enforced centrally). Mechanical; identical across all consumers.

Note: the `uses: ...@production` ref is correct — Rollout 1c renamed `vyos/.github`'s default branch `current`→`production` (2026-05-30); `@current` is the stale pre-1c form. Matches vyatta-biosdevname / ipaddrcheck / libpam-tacplus (already in production).

Tracking: T8943.

🤖 Generated by [robots](https://vyos.io)