### PR TITLE
docs: AGENTS.md: reflect rollout 1c default-branch rename (current->rolling)

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -31,7 +31,7 @@ No application-level test runner — the package is exercised at runtime by `vyo
 
 ## Conventions
 - Commit/PR title: `component: T12345: description` (Phorge task ID at https://vyos.dev). Enforced by `check-pr-message.yml` reusable.
-- Workflows: `pr-mirror-repo-sync.yml`, `trigger-rebuild-repo-package.yml`, `codeql.yml`, `cla-check.yml` (all `vyos/.github@current` reusables).
+- Workflows: `pr-mirror-repo-sync.yml`, `trigger-rebuild-repo-package.yml`, `codeql.yml`, `cla-check.yml` (all `vyos/.github@production` reusables).
 - Bumping `requirements.in` → regenerate `requirements.txt` via `pip-compile` (`pip-tools`) in the same PR. Pin full graph for reproducible builds.
 
 ## Notes for future contributors


### PR DESCRIPTION
Updates `AGENTS.md` to reflect the rollout 1c default-branch rename (release-train repos `current`->`rolling`; `vyos/.github` + non-release-train `current`->`production`) and the corresponding `@current`->`@production` reusable-workflow refs.

Tracking: Phorge [T8943](https://vyos.dev/T8943) (the 1c rename that caused the drift).

Doc-only change to `AGENTS.md`. No code or workflow behavior changes.

🤖 Generated by [robots](https://vyos.io)