### PR TITLE
ci(mirror-rollout-4): add force_workspace backport companion wrapper

### DIFF
--- a/.github/workflows/force-workspace-backport.yml
+++ b/.github/workflows/force-workspace-backport.yml
@@ -1,0 +1,25 @@
+# .github/workflows/force-workspace-backport.yml
+# DO NOT EDIT — managed by mirror-pipeline Rollout 4.
+name: force_workspace backport companion
+
+on:
+  issue_comment:
+    types: [created]
+
+permissions:
+  contents: read
+
+jobs:
+  call:
+    # No-op on the public source (owner != VyOS-Networks); active on the mirrored target copy.
+    if: |
+      github.repository_owner == 'VyOS-Networks'
+      && github.event.issue.pull_request != null
+      && github.event.comment.user.login == 'mergify[bot]'
+      && contains(github.event.comment.body, 'No backport have been created')
+    uses: vyos/.github/.github/workflows/force-workspace-backport.yml@production
+    with:
+      mergify_comment_id: ${{ github.event.comment.id }}
+      mergify_comment_body: ${{ github.event.comment.body }}
+      target_pr_number: ${{ github.event.issue.number }}
+    secrets: inherit


### PR DESCRIPTION
Rollout 4 (IS-510, Phorge T8943). Byte-identical source-side force_workspace wrapper (Phase-0 + adversarial cleared on the vyos/ipaddrcheck representative). Inert until force_workspace_enabled per-consumer (default false). Mirrors to the VyOS-Networks twin where it's active.

🤖 Generated by [robots](https://vyos.io)